### PR TITLE
Add server-side file validation and error handling for non-JPG uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
 import tensorflow as tf
 import numpy as np
 import logging
-from PIL import Image
+from pathlib import Path
+from PIL import Image, UnidentifiedImageError
 from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2, preprocess_input
 from flask import Flask, request, render_template
 from flask.logging import create_logger
@@ -19,13 +20,24 @@ model = MobileNetV2(weights="imagenet")
 def home():
     return render_template("view.html")
 
+ALLOWED_EXTENSIONS = {".jpg"}
+
+
+def allowed_file(filename):
+    return Path(filename).suffix.lower() in ALLOWED_EXTENSIONS
+
+
 # Preprocessing an image before feeding it into a neural network, specifically a MobileNetV2 model. It
 # resizes the image to a square shape with dimensions of 224x224 pixels. MobileNetV2, expect input
 # images of a specific size.
 # The deep learning framework Keras preprocesses the image array to be compatible with the MobileNetV2
 # model. It may involve normalization and other transformations.
 def prepare_image(image):
-    img = Image.open(image)
+    try:
+        img = Image.open(image)
+    except UnidentifiedImageError:
+        LOG.error("Uploaded file is not a valid image")
+        raise
     img = img.resize((224, 224))
     img_array = np.array(img)
     LOG.info("Format, resize and process image...")
@@ -37,9 +49,15 @@ def prepare_image(image):
 # The model return a list of the top 3 posible results with highest probability.
 @app.route("/predict", methods=["POST"])
 def predict():
-    image = request.files["image"]
+    image_file = request.files["image"]
+    if image_file.filename == "" or not allowed_file(image_file.filename):
+        LOG.warning(f"Invalid file type: {image_file.filename}")
+        return render_template("view.html", error="Only .jpg images are allowed."), 400
     LOG.info("Processing image...")
-    img_array = prepare_image(image)
+    try:
+        img_array = prepare_image(image_file)
+    except UnidentifiedImageError:
+        return render_template("view.html", error="The uploaded file is not a valid image."), 400
     LOG.info("Calling to model...")
     prediction = model.predict(img_array)
     results = tf.keras.applications.mobilenet_v2.decode_predictions(prediction, top=3)[0]

--- a/templates/view.html
+++ b/templates/view.html
@@ -76,6 +76,9 @@
 		}
 	</script>
 
+	{% if error %}
+		<p style="color: red; text-align: center;"><strong>{{ error }}</strong></p>
+	{% endif %}
 	<form action="/predict" method="post" enctype="multipart/form-data">
 		<input type="file" name="image" id="image" accept=".jpg" onchange="validateFile()" required>
 		<p style="color: red;">Only JPG images are allowed.</p>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from io import BytesIO
 from PIL import Image as PILImage
-from app import prepare_image
+from app import prepare_image, allowed_file
 
 
 class TestHomeEndpoint:
@@ -52,6 +52,23 @@ class TestPrepareImage:
             prepare_image("images/invalid_image_path.jpg")
 
 
+class TestAllowedFile:
+    def test_allows_jpg(self):
+        assert allowed_file("image.jpg") is True
+
+    def test_allows_jpg_uppercase(self):
+        assert allowed_file("image.JPG") is True
+
+    def test_rejects_png(self):
+        assert allowed_file("image.png") is False
+
+    def test_rejects_no_extension(self):
+        assert allowed_file("image") is False
+
+    def test_rejects_empty_filename(self):
+        assert allowed_file("") is False
+
+
 class TestPredictEndpoint:
     def test_predict_returns_200_with_valid_image(self, client, valid_image_bytes):
         response = client.post(
@@ -89,3 +106,41 @@ class TestPredictEndpoint:
     def test_predict_rejects_get_request(self, client):
         response = client.get("/predict")
         assert response.status_code == 405
+
+    def test_predict_rejects_png_file(self, client, valid_image_bytes):
+        response = client.post(
+            "/predict",
+            data={"image": (valid_image_bytes, "test.png")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+        content = response.data.decode("utf-8")
+        assert "Only .jpg images are allowed" in content
+
+    def test_predict_rejects_txt_file(self, client):
+        response = client.post(
+            "/predict",
+            data={"image": (BytesIO(b"not an image"), "document.txt")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+        content = response.data.decode("utf-8")
+        assert "Only .jpg images are allowed" in content
+
+    def test_predict_rejects_corrupted_jpg(self, client):
+        response = client.post(
+            "/predict",
+            data={"image": (BytesIO(b"not an image"), "image.jpg")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400
+        content = response.data.decode("utf-8")
+        assert "not a valid image" in content
+
+    def test_predict_rejects_empty_filename(self, client, valid_image_bytes):
+        response = client.post(
+            "/predict",
+            data={"image": (valid_image_bytes, "")},
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary

Fixes #4 by adding server-side validation for uploaded files and proper error handling for corrupted/invalid images.

## Changes

1. **Server-side file extension validation** (`app.py`): Added `allowed_file()` function that rejects any file that isn't `.jpg`. The client-side JS validation was trivially bypassable via direct API requests.

2. **Corrupted image handling** (`app.py`): Added `try/except UnidentifiedImageError` in `prepare_image()` and `predict()` to catch invalid image files with a `.jpg` extension.

3. **Error display** (`view.html`): Added Jinja2 template block to display server-side error messages in the upload form.

4. **Tests** (`test_app.py`): Added 9 new tests:
   - `TestAllowedFile` (5 tests): validates extension checking
   - `TestPredictEndpoint` (4 new tests): rejects PNG, .txt, corrupted .jpg, empty filename

## ML Library Analysis

MobileNetV2 via TensorFlow accepts any valid RGB image array — the `.jpg` restriction is a project policy, not a model limitation. PIL/Pillow can decode many formats (JPEG, PNG, BMP, GIF, WebP, TIFF) into RGB arrays. However, non-image files (e.g., `.txt`, `.exe`) will raise `PIL.UnidentifiedImageError` when opened with `Image.open()`.